### PR TITLE
Fix bug where delete menu appears for non-root posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Post Delete Helper 
 
+[![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-post-delete-helper)](https://github.com/mattermost/mattermost-plugin-post-delete-helper/releases/latest)
 [![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-post-delete-helper/master)](https://circleci.com/gh/mattermost/mattermost-plugin-post-delete-helper)
 
 ## Features

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -32,8 +32,8 @@ export default class Plugin {
 
                 //console.debug('reply_count=', post.reply_count, '  rootdel=', post.props?.rootdel, '  root_id=', post.root_id, '  post_id=', post.id); //eslint-disable-line no-console
 
-                // check if this is a root post (non-empty root_id means this is a reply post)
-                if (post.root_id) {
+                // check if this is a root post (non-empty root_id means this is a reply post) and has replies.
+                if (post.root_id && post.reply_count > 0) {
                     return false;
                 }
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -32,12 +32,12 @@ export default class Plugin {
 
                 // console.debug('reply_count=', post.reply_count, '  rootdel=', post.props?.rootdel, '  root_id=', post.root_id, '  post_id=', post.id); //eslint-disable-line no-console
 
-                // check if this is a root post (non-empty root_id means this is a reply post) and has replies.
+                // hide menu if this is not a root post (non-empty root_id means this is a reply post) or has no replies.
                 if (post.root_id || post.reply_count === 0) {
                     return false;
                 }
 
-                // check if post is already marked as root post deleted
+                // hide menu if post is already marked as root post deleted
                 if (post.props && post.props.rootdel) {
                     return false;
                 }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -30,10 +30,10 @@ export default class Plugin {
                     return false;
                 }
 
-                // console.debug('reply_count=', post.reply_count, '  rootdel=', post.props?.rootdel, '  post_id=', post.id); //eslint-disable-line no-console
+                //console.debug('reply_count=', post.reply_count, '  rootdel=', post.props?.rootdel, '  root_id=', post.root_id, '  post_id=', post.id); //eslint-disable-line no-console
 
-                // check if post has replies
-                if (post.reply_count === 0) {
+                // check if this is a root post (non-empty root_id means this is a reply post)
+                if (post.root_id) {
                     return false;
                 }
 
@@ -42,7 +42,9 @@ export default class Plugin {
                     return false;
                 }
 
-                // Check if the user has permissions to edit his own post or edit other's posts if not the author
+                // Check if the user has permissions to edit his own post, or other's posts if not the author.
+                // We check for edit permissions instead of delete since on the back-end we will be editing the
+                // post and making it immutable.
                 const user = getCurrentUser(state);
                 const team = getCurrentTeam(state);
                 let permission = Permissions.EDIT_POST;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -30,10 +30,10 @@ export default class Plugin {
                     return false;
                 }
 
-                //console.debug('reply_count=', post.reply_count, '  rootdel=', post.props?.rootdel, '  root_id=', post.root_id, '  post_id=', post.id); //eslint-disable-line no-console
+                // console.debug('reply_count=', post.reply_count, '  rootdel=', post.props?.rootdel, '  root_id=', post.root_id, '  post_id=', post.id); //eslint-disable-line no-console
 
                 // check if this is a root post (non-empty root_id means this is a reply post) and has replies.
-                if (post.root_id && post.reply_count > 0) {
+                if (post.root_id || post.reply_count === 0) {
                     return false;
                 }
 


### PR DESCRIPTION
#### Summary
This PR fixes a bug where the Delete Root post menu appears for posts that are not root posts.

I was relying on ReplyCount being accurate to determine if a post has replies. On the client the ReplyCount can become non-zero for non-root posts when more replies are added.  It gets fixed on page reload, which is why I missed it, but is inaccurate until refresh. 

The fix is to check that root_id is empty (meaning root post) and the reply count is non-zero.

#### Ticket Link
https://hub.mattermost.com/private-core/pl/stzhhdk3gtri7r8uezngo5xyww
