### PR TITLE
Check if post already deleted; use same checks for slash commands as API

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -62,13 +62,9 @@ func (a *API) handlerDeleteRootPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if post.RootId != "" {
-		// not root of a thread so just delete it normally
-		if appErr = a.plugin.API.DeletePost(post.Id); appErr != nil {
-			http.Error(w, appErr.Error(), appErr.StatusCode)
-		} else {
-			w.WriteHeader(http.StatusOK)
-		}
+	// Check if the post is a root post
+	if post.RootId != "" || post.ReplyCount == 0 {
+		http.Error(w, "Post is not a root post of a thread", http.StatusBadRequest)
 		return
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -50,21 +50,9 @@ func (a *API) handlerDeleteRootPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if post is already deleted
-	if post.DeleteAt != 0 {
-		http.Error(w, "Post already deleted", http.StatusBadRequest)
-		return
-	}
-
-	// Check if the user is the post author or a system admin
-	if errReason := a.plugin.userHasRemovePermissionsToPost(userID, post.ChannelId, postID); errReason != "" {
-		http.Error(w, errReason, http.StatusForbidden)
-		return
-	}
-
-	// Check if the post is a root post
-	if post.RootId != "" || post.ReplyCount == 0 {
-		http.Error(w, "Post is not a root post of a thread", http.StatusBadRequest)
+	// Check if root post can be deleted
+	if code, err := a.plugin.checkCanDeleteRootPost(userID, post); err != nil {
+		http.Error(w, err.Error(), code)
 		return
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -50,13 +50,19 @@ func (a *API) handlerDeleteRootPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if post is already deleted
+	if post.DeleteAt != 0 {
+		http.Error(w, "Post already deleted", http.StatusBadRequest)
+		return
+	}
+
 	// Check if the user is the post author or a system admin
 	if errReason := a.plugin.userHasRemovePermissionsToPost(userID, post.ChannelId, postID); errReason != "" {
 		http.Error(w, errReason, http.StatusForbidden)
 		return
 	}
 
-	if post.ReplyCount <= 0 {
+	if post.RootId != "" {
 		// not root of a thread so just delete it normally
 		if appErr = a.plugin.API.DeletePost(post.Id); appErr != nil {
 			http.Error(w, appErr.Error(), appErr.StatusCode)

--- a/server/commands.go
+++ b/server/commands.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -49,19 +51,9 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		return p.createErrorCommandResponse("cannot fetch post - " + appErr.Error()), nil
 	}
 
-	// Check if post is already deleted
-	if post.DeleteAt != 0 {
-		return p.createErrorCommandResponse("post is already deleted."), nil
-	}
-
-	// Check if post is root of a thread (has replies)
-	if post.RootId != "" || post.ReplyCount == 0 {
-		return p.createErrorCommandResponse("post is not root of a thread."), nil
-	}
-
-	// Check if the user has permissions to remove the post
-	if errReason := p.userHasRemovePermissionsToPost(args.UserId, args.ChannelId, postID); errReason != "" {
-		return p.createErrorCommandResponse(errReason), nil
+	// Check if root post can be deleted
+	if _, err := p.checkCanDeleteRootPost(args.UserId, post); err != nil {
+		return p.createErrorCommandResponse(err.Error()), nil
 	}
 
 	// Create an interactive dialog to confirm the action
@@ -79,4 +71,22 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 
 	// Return nothing, let the dialog/api handle the response
 	return &model.CommandResponse{}, nil
+}
+
+func (p *Plugin) checkCanDeleteRootPost(userID string, post *model.Post) (int, error) {
+	// Check if post is already deleted
+	if post.DeleteAt != 0 {
+		return http.StatusBadRequest, errors.New("post already deleted")
+	}
+
+	// Check if the user is the post author or a system admin
+	if errReason := p.userHasRemovePermissionsToPost(userID, post.ChannelId, post.Id); errReason != "" {
+		return http.StatusForbidden, errors.New(errReason)
+	}
+
+	// Check if the post is a root post
+	if post.RootId != "" || post.ReplyCount == 0 {
+		return http.StatusBadRequest, errors.New("post is not root of a thread")
+	}
+	return http.StatusOK, nil
 }

--- a/server/commands.go
+++ b/server/commands.go
@@ -55,8 +55,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	}
 
 	// Check if post is root of a thread (has replies)
-	if post.RootId != "" {
-		return p.createErrorCommandResponse("post is not root (has no replies)."), nil
+	if post.RootId != "" || post.ReplyCount == 0 {
+		return p.createErrorCommandResponse("post is not root of a thread."), nil
 	}
 
 	// Check if the user has permissions to remove the post

--- a/server/commands.go
+++ b/server/commands.go
@@ -79,6 +79,13 @@ func (p *Plugin) checkCanDeleteRootPost(userID string, post *model.Post) (int, e
 		return http.StatusBadRequest, errors.New("post already deleted")
 	}
 
+	// Check if post is already root deleted by this plugin
+	val := post.GetProp(DeletedRootPostPropKey)
+	deleted, ok := val.(bool)
+	if ok && deleted {
+		return http.StatusBadRequest, errors.New("root post already deleted")
+	}
+
 	// Check if the user is the post author or a system admin
 	if errReason := p.userHasRemovePermissionsToPost(userID, post.ChannelId, post.Id); errReason != "" {
 		return http.StatusForbidden, errors.New(errReason)


### PR DESCRIPTION
### Summary
This PR addresses [some issues found during QA](https://hub.mattermost.com/private-core/pl/xbbbifwk93g49ghp6ngb8r9fao).  

#### Root Post without Replies:
- The "Remove root post" option is not available for root posts without any replies, which is the expected behavior. However, using the /deleterootpost slash command successfully deletes the root post, functioning the same as the built-in delete option. Is this behavior expected, or should the command follow the same logic as the UI option?

- **Fixed:**  `/deleterootpost` now checks that the post is root, has replies, and errors if condition not met

#### Reply Posts
- The "Remove root post" option is not available for reply posts, which is expected. However, using the /deleterootpost command on a reply post deletes the reply, similar to how the plugin deletes the root post. Should the command follow the same logic as the UI option?

- **Fixed:** `/deleterootpost` now checks that the post is root, has replies, and errors if condition not met

#### Re-executing the slash command to the deleted root post
- Currently, re-executing the slash command with the same (already deleted) root post ID results in the following behavior:
    - The dialog still opens.
    - Clicking "Delete" in the dialog closes it but does nothing afterward.
This current behavior seems to be a not good user experience. IMO, the dialog should not appear for a deleted post, and a clear message indicating the root post has already been deleted would be more intuitive

- **Fixed:** Slash command and `/deleterootpost` provide error message when post is already deleted.


### Ticket Link
see https://hub.mattermost.com/private-core/pl/xbbbifwk93g49ghp6ngb8r9fao
